### PR TITLE
v0.1.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
 # mage-http-server.js changelog
 
+## v0.1.1
+ * Updated dependency mage-http-request.js from [v0.1.0](https://github.com/mage/http-request.js/releases/tag/0.1.0) to [v0.1.1](https://github.com/mage/http-request.js/releases/tag/0.1.1)
+ * Added strict type checks to sendcommand
+
 ## v0.1.0
  * Initial Release

--- a/component.json
+++ b/component.json
@@ -1,10 +1,10 @@
 {
 	"name": "mage-http-server.js",
 	"repo": "mage/http-server.js",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "MAGE's http server",
 	"dependencies": {
-		"mage/http-request.js": "0.1.0"
+		"mage/http-request.js": "0.1.1"
 	},
 	"scripts": [
 		"index.js"

--- a/index.js
+++ b/index.js
@@ -450,6 +450,18 @@ HttpServer.prototype.setupCommandSystem = function (config) {
 
 
 	this.sendCommand = function (cmdName, params, cb) {
+		if (typeof cmdName !== 'string') {
+			throw new TypeError('Command name is not a string: ' + cmdName);
+		}
+
+		if (params && typeof params !== 'object') {
+			throw new TypeError('Command params is not an object: ' + params);
+		}
+
+		if (cb && typeof cb !== 'function') {
+			throw new TypeError('Command callback is not a function: ' + cb);
+		}
+
 		// cmdName is dot notation "moduleName.commandName"
 
 		// Serialize the params instantly, so that they may be altered right after this call without


### PR DESCRIPTION
- Updated dependency mage-http-request.js from [v0.1.0](https://github.com/mage/http-request.js/releases/tag/0.1.0) to [v0.1.1](https://github.com/mage/http-request.js/releases/tag/0.1.1)
- Added strict type checks to sendcommand
